### PR TITLE
Remove "donation" wording to appease the expense report overlords

### DIFF
--- a/pages/registration.md
+++ b/pages/registration.md
@@ -19,9 +19,9 @@ Computing (SSC) members.
     - $25 for ASA members but not SSC members
     - $40 for non-ASA members
 - Group watch-party:
-    - Register once to host a "watch-party" for students and/or colleagues.
+    - $200 - or contact us for special pricing.
         - Los Angeles - [UCLA Watch Party](https://calendar.library.ucla.edu/event/11429849?k=0d1dd3535f028173994172bf454b29ac) 
-    - We suggest a $100 donation to support the section, but will thankfully accept more.  😀
+    
 
 For non-ASA members, please consider [joining
 ASA](https://www.amstat.org/membership/become-a-member). 


### PR DESCRIPTION

I ran a campus watch party last year. I submitted the registration on my personal card, ran the event, that part worked fine.

However, my university's purchasing department keeps rejecting my expense report because of the word 'donation' on the reciept. 

Next year, please use different language instead. And you may as well adjust the price while you are at it.

```
Expense Report Status Change
The below expense report has changed status.
Changed By

 	
NAME REDACTED

Report Name

 	
ASA Statistical Computing Workshop

Report Date

 	
12/04/2023

Submit Date

 	
01/10/2024

 
Amount Approved

 	
100.00 USD

 
Approval Status Set To

 	
Sent Back to Employee

Payment Status Set To

 	
Not Paid

Approver's Comments

Hello,

The description on the receipt reflects there is a donation. Can you please confirm if there was a donation with this payment?

As a reminder, we are unable to reimburse amounts paid for voluntary donation contributions made by employees as these must be directly made by the university.
```